### PR TITLE
Add issue dampening to improve report safety tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Each puzzle's task is reframed below according to my understanding of the task.
 
 ### Puzzle 1
 
-An input file (`data/levels.txt`) with rows detailing reports of levels should be scanned to report which rows ("reports") are safe and which are not. A "safe" report consitutes one in which the levels are all consecutively increasing or decreasing across the entire row by only 1-2 unit increments between consecutive levels. Anything else is "unsafe."
+An input file (`data/levels.txt`) with rows detailing reports of levels should be scanned to report which rows ("reports") are safe and which are not. A "safe" report constitutes one in which the levels are all consecutively increasing or decreasing across the entire row by only 1-2 unit increments between consecutive levels. Anything else is "unsafe."
 
 ### Puzzle 2
 
-**TBD**: pending completion of **Puzzle 1**.
+The same conditions hold, but the tolerance for errors has increased such that if a single value in a level report is removed and the line is otherwise safe, this now constitutes a "safe" line.

--- a/red_nosed_reports/red_nosed_reports.py
+++ b/red_nosed_reports/red_nosed_reports.py
@@ -38,11 +38,41 @@ def is_appropriately_incrementing(report_line: report) -> bool:
     return _appropriate_increment
 
 
-def determine_safety(report_line: report) -> bool:
+def dampen_issue(report_line: report, i: int) -> bool:
+    _unsafe_report = list(report_line)
+    del _unsafe_report[i]
+    _modified_report = tuple(_unsafe_report)
+
+    _ordered = is_ordered(_modified_report)
+    _unique = is_unique(_modified_report)
+    _incrementing = is_appropriately_incrementing(_modified_report)
+    return _ordered and _unique and _incrementing
+
+
+def attempt_issue_dampening(report_line: report) -> bool:
+    return any([dampen_issue(report_line, i)
+                for i, _ in enumerate(report_line)])
+
+
+def determine_strict_safety(report_line: report) -> bool:
     _ordered: bool = is_ordered(report_line)
     _unique: bool = is_unique(report_line)
     _incrementing: bool = is_appropriately_incrementing(report_line)
     return _ordered and _unique and _incrementing
+
+
+def determine_dampened_safety(report_line: report) -> bool:
+    _ordered: bool = is_ordered(report_line)
+    _unique: bool = is_unique(report_line)
+    _incrementing: bool = is_appropriately_incrementing(report_line)
+    _conditions_met = _ordered + _unique + _incrementing
+
+    _safe: bool = False
+    if _conditions_met == 3:
+        _safe = True
+    else:
+        _safe = attempt_issue_dampening(report_line)
+    return _safe
 
 
 def parse_input(corpus: str) -> tuple[tuple[int, ...], ...]:
@@ -53,9 +83,18 @@ def parse_input(corpus: str) -> tuple[tuple[int, ...], ...]:
 def main():
     contents = read_data_file("level_reports.txt")
     parsed_contents = parse_input(contents)
-    safe_reports = [determine_safety(_line) for _line in parsed_contents]
+
     print("\nPart 1\n------")
-    print(f"The total number of safe reports is {sum(safe_reports):,}.")
+    strictly_safe_reports = [determine_strict_safety(_line)
+                             for _line in parsed_contents]
+    print("The total number of safe reports is "
+          f"{sum(strictly_safe_reports):,}.")
+
+    print("\nPart 2\n------")
+    dampened_safe_reports = [determine_dampened_safety(_line)
+                             for _line in parsed_contents]
+    print("The total number of safe reports is "
+          f"{sum(dampened_safe_reports):,}.")
 
 
 if __name__ == "__main__":

--- a/red_nosed_reports/tests/test_red_nosed_reports.py
+++ b/red_nosed_reports/tests/test_red_nosed_reports.py
@@ -92,7 +92,7 @@ def test_is_appropriately_incrementing(report_line: report, expected: bool):
     )
 )
 def test_determine_safety_strict(report_line: report, expected):
-    assert rnr.determine_safety(report_line) == expected
+    assert rnr.determine_strict_safety(report_line) == expected
 
 
 @pytest.mark.parametrize(
@@ -100,12 +100,12 @@ def test_determine_safety_strict(report_line: report, expected):
     (
         pytest.param((1, 2, 3, 3, 5), True,
                      id="Testing dampened safety: safe, if repetition dampened."),
-        pytest.param((10, 9, 5, 4, 3), True,
+        pytest.param((10, 6, 5, 4, 3), True,
                      id="Testing dampened safety: safe, if increment dampened."),
         pytest.param((1, 2, 3, 5, 4), True,
                      id="Testing dampened safety: safe, if disorder dampened.")
     )
 )
 def test_determine_safety_dampened(report_line: report, expected):
-    assert rnr.determine_safety(report_line) == expected
+    assert rnr.determine_dampened_safety(report_line) == expected
 

--- a/red_nosed_reports/tests/test_red_nosed_reports.py
+++ b/red_nosed_reports/tests/test_red_nosed_reports.py
@@ -91,5 +91,21 @@ def test_is_appropriately_incrementing(report_line: report, expected: bool):
                      id="Testing safety: unsafe, ascending, unique, non-incrementing.")
     )
 )
-def test_determine_safety(report_line: report, expected):
+def test_determine_safety_strict(report_line: report, expected):
     assert rnr.determine_safety(report_line) == expected
+
+
+@pytest.mark.parametrize(
+    ("report_line", "expected"),
+    (
+        pytest.param((1, 2, 3, 3, 5), True,
+                     id="Testing dampened safety: safe, if repetition dampened."),
+        pytest.param((10, 9, 5, 4, 3), True,
+                     id="Testing dampened safety: safe, if increment dampened."),
+        pytest.param((1, 2, 3, 5, 4), True,
+                     id="Testing dampened safety: safe, if disorder dampened.")
+    )
+)
+def test_determine_safety_dampened(report_line: report, expected):
+    assert rnr.determine_safety(report_line) == expected
+


### PR DESCRIPTION
If a report is deemed "unsafe," it is now rerouted to an "issue dampener" pathway. This pathway removes one level value from the unsafe report per iteration, removing each level once along the way, and re-tests the modified report for safety. If any value-removal operation results in the report being deemed "safe," the entire report is deemed to be "safe."

More tests were added to verify this issue-dampening behavior.